### PR TITLE
Fix: php warnings

### DIFF
--- a/pnfpb_push_notification.php
+++ b/pnfpb_push_notification.php
@@ -9367,7 +9367,7 @@ if ( !class_exists( 'PNFPB_ICFM_Push_Notification_Post_BuddyPress' ) ) {
 			$is_firebase_version_col = $wpdb->get_results(  "SELECT `COLUMN_NAME` FROM `INFORMATION_SCHEMA`.`COLUMNS` WHERE `table_name` = '{$table}' AND `TABLE_SCHEMA` = '{$dbname}' AND `COLUMN_NAME` = 'firebase_version'"  );
 
 			if( empty($is_firebase_version_col) ):
-				$add_status_column = "ALTER TABLE `{$table}` ADD `firebase_version` VARCHAR(100) DEFAULT 'L'; ";
+				$add_firebase_version_column = "ALTER TABLE `{$table}` ADD `firebase_version` VARCHAR(100) DEFAULT 'L'; ";
 				$wpdb->query( $add_firebase_version_column );
 			endif;			
 			

--- a/public/ajax_routines/pnfpb_update_deviceid_ajax.php
+++ b/public/ajax_routines/pnfpb_update_deviceid_ajax.php
@@ -69,7 +69,7 @@
  	$is_firebase_version_col = $wpdb->get_results(  "SELECT `COLUMN_NAME` FROM `INFORMATION_SCHEMA`.`COLUMNS` WHERE `table_name` = '{$table}' AND `TABLE_SCHEMA` = '{$dbname}' AND `COLUMN_NAME` = 'firebase_version'"  );
 
 	if( empty($is_firebase_version_col) ):
-    	$add_status_column = "ALTER TABLE `{$table}` ADD `firebase_version` VARCHAR(100) DEFAULT 'L'; ";
+    	$add_firebase_version_column = "ALTER TABLE `{$table}` ADD `firebase_version` VARCHAR(100) DEFAULT 'L'; ";
    		$wpdb->query( $add_firebase_version_column );
 	endif;	
 	

--- a/public/service_worker/pnfpb_create_sw_file.php
+++ b/public/service_worker/pnfpb_create_sw_file.php
@@ -42,8 +42,14 @@ if ( !function_exists( 'PNFPB_icfm_icpush_add_rewrite_rules' )) {
 if ( !function_exists( 'PNFPB_icfm_icpush_generate_sw_pwajson' )) {
 	function PNFPB_icfm_icpush_generate_sw_pwajson( $query ) {
 		if ( ! property_exists( $query, 'query_vars' ) || ! is_array( $query->query_vars ) ) {
-		return;
+			return;
 		}
+
+		// skip if it's multi dimensional array.
+		if ( count( $query->query_vars ) !== count( $query->query_vars, COUNT_RECURSIVE ) ) {
+			return;
+		}
+
 		$query_vars_as_string = implode( ' ', $query->query_vars );
 		$sw_filename = 'pnfpb_icpush_pwa_sw.js';
 		$sw_filename_firebasesw = 'firebase-messaging-sw.js';


### PR DESCRIPTION
Fixes for some PHP warnings when running the plugin.

Is this the correct place to submit pull requests for the plugin?
I noticed the version of the plugin here in GitHub is still `1.87` while in the [plugin directory](https://wordpress.org/plugins/push-notification-for-post-and-buddypress/#developers) it is `1.93`.